### PR TITLE
Add sliding page transition example

### DIFF
--- a/my-app/package.json
+++ b/my-app/package.json
@@ -16,7 +16,9 @@
     "i18next": "^23.0.0",
     "zustand": "^4.4.0",
     "@apollo/client": "^3.9.0",
-    "graphql": "^16.0.0"
+    "graphql": "^16.0.0",
+    "react-router-dom": "^6.21.2",
+    "framer-motion": "^11.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -1,8 +1,42 @@
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { AnimatePresence } from 'framer-motion';
 import HomeContainer from './containers/HomeContainer';
+import AboutContainer from './containers/AboutContainer';
+import PageTransition from './components/PageTransition';
 import './i18n';
 
+const AnimatedRoutes = () => {
+  const location = useLocation();
+  return (
+    <AnimatePresence mode="wait">
+      <Routes location={location} key={location.pathname}>
+        <Route
+          path="/"
+          element={
+            <PageTransition>
+              <HomeContainer />
+            </PageTransition>
+          }
+        />
+        <Route
+          path="/about"
+          element={
+            <PageTransition>
+              <AboutContainer />
+            </PageTransition>
+          }
+        />
+      </Routes>
+    </AnimatePresence>
+  );
+};
+
 function App() {
-  return <HomeContainer />;
+  return (
+    <BrowserRouter>
+      <AnimatedRoutes />
+    </BrowserRouter>
+  );
 }
 
 export default App;

--- a/my-app/src/components/PageTransition.tsx
+++ b/my-app/src/components/PageTransition.tsx
@@ -1,0 +1,27 @@
+import { motion } from 'framer-motion';
+import type { ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+const variants = {
+  initial: { x: '100%', opacity: 0 },
+  animate: { x: 0, opacity: 1 },
+  exit: { x: '-100%', opacity: 0 },
+};
+
+const PageTransition = ({ children }: Props) => (
+  <motion.div
+    variants={variants}
+    initial="initial"
+    animate="animate"
+    exit="exit"
+    transition={{ type: 'tween', duration: 0.3 }}
+    style={{ width: '100%' }}
+  >
+    {children}
+  </motion.div>
+);
+
+export default PageTransition;

--- a/my-app/src/containers/AboutContainer.tsx
+++ b/my-app/src/containers/AboutContainer.tsx
@@ -1,0 +1,12 @@
+import type { FC } from 'react';
+import { Link } from 'react-router-dom';
+
+const AboutContainer: FC = () => (
+  <div>
+    <h2>About Page</h2>
+    <p>This is the about page.</p>
+    <Link to="/">Go Home</Link>
+  </div>
+);
+
+export default AboutContainer;

--- a/my-app/src/containers/HomeContainer.tsx
+++ b/my-app/src/containers/HomeContainer.tsx
@@ -1,6 +1,7 @@
 import type { FC } from 'react';
 import Hello from '../components/Hello';
 import { useStore } from '../store/useStore';
+import { Link } from 'react-router-dom';
 
 const HomeContainer: FC = () => {
   const count = useStore((state) => state.count);
@@ -11,6 +12,9 @@ const HomeContainer: FC = () => {
       <Hello />
       <p>count: {count}</p>
       <button onClick={increase}>+</button>
+      <div>
+        <Link to="/about">Go to About</Link>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add React Router and framer-motion dependencies
- implement animated routes with sliding transition
- add About page and navigation links

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685260777144832ea8cf6fd161f3ceaf