### PR TITLE
Add configurable page transition variants

### DIFF
--- a/my-app/src/App.tsx
+++ b/my-app/src/App.tsx
@@ -7,13 +7,14 @@ import './i18n';
 
 const AnimatedRoutes = () => {
   const location = useLocation();
+  const animation = (location.state as { animation?: 'menu' | 'sub' | 'back' } | null)?.animation;
   return (
     <AnimatePresence mode="wait" initial={false}>
       <Routes location={location} key={location.pathname}>
         <Route
           path="/"
           element={
-            <PageTransition>
+            <PageTransition animation={animation ?? 'menu'}>
               <HomeContainer />
             </PageTransition>
           }
@@ -21,7 +22,7 @@ const AnimatedRoutes = () => {
         <Route
           path="/about"
           element={
-            <PageTransition>
+            <PageTransition animation={animation ?? 'sub'}>
               <AboutContainer />
             </PageTransition>
           }

--- a/my-app/src/components/PageTransition.tsx
+++ b/my-app/src/components/PageTransition.tsx
@@ -3,17 +3,36 @@ import type { ReactNode } from 'react';
 
 interface Props {
   children: ReactNode;
+  /**
+   * 애니메이션 종류
+   * - 'menu': 메뉴에서 페이지 진입
+   * - 'sub':  페이지에서 세부 페이지 진입
+   * - 'back': 뒤로가기
+   */
+  animation?: 'menu' | 'sub' | 'back';
 }
 
 const variants = {
-  initial: { x: '100%', opacity: 0 },
-  animate: { x: 0, opacity: 1 },
-  exit: { x: '-100%', opacity: 0 },
-};
+  menu: {
+    initial: { x: '100%', opacity: 0 },
+    animate: { x: 0, opacity: 1 },
+    exit: { x: '-100%', opacity: 0 },
+  },
+  sub: {
+    initial: { y: '100%', opacity: 0 },
+    animate: { y: 0, opacity: 1 },
+    exit: { y: '-100%', opacity: 0 },
+  },
+  back: {
+    initial: { x: '-100%', opacity: 0 },
+    animate: { x: 0, opacity: 1 },
+    exit: { x: '100%', opacity: 0 },
+  },
+} as const;
 
-const PageTransition = ({ children }: Props) => (
+const PageTransition = ({ children, animation = 'menu' }: Props) => (
   <motion.div
-    variants={variants}
+    variants={variants[animation]}
     initial="initial"
     animate="animate"
     exit="exit"

--- a/my-app/src/containers/AboutContainer.tsx
+++ b/my-app/src/containers/AboutContainer.tsx
@@ -5,7 +5,9 @@ const AboutContainer: FC = () => (
   <div>
     <h2>About Page</h2>
     <p>This is the about page.</p>
-    <Link to="/">Go Home</Link>
+    <Link to="/" state={{ animation: 'back' }}>
+      Go Home
+    </Link>
   </div>
 );
 

--- a/my-app/src/containers/HomeContainer.tsx
+++ b/my-app/src/containers/HomeContainer.tsx
@@ -13,7 +13,9 @@ const HomeContainer: FC = () => {
       <p>count: {count}</p>
       <button onClick={increase}>+</button>
       <div>
-        <Link to="/about">Go to About</Link>
+        <Link to="/about" state={{ animation: 'sub' }}>
+          Go to About
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow specifying animation variants in `PageTransition`
- drive page transitions with navigation state in `App`
- send the proper `animation` state with links

## Testing
- `yarn test` *(fails: package not in lockfile)*


------
https://chatgpt.com/codex/tasks/task_b_68526d26f7b8832ead82a88b964793e5